### PR TITLE
Integrate routines to truncate table and a simple test to check POST sentence

### DIFF
--- a/tests/db.rs
+++ b/tests/db.rs
@@ -1,0 +1,47 @@
+extern crate postgres;
+
+use std::env;
+
+use self::postgres::{
+    Connection,
+    TlsMode,
+};
+use self::postgres::params::{
+    ConnectParams,
+    Host,
+};
+
+/// Create the connection parameters from environment variables
+/// DB_USER
+/// DB_PASSWORD
+/// DB_HOST
+/// DB_NAME
+/// we fail if any is missing
+fn create_connection_params_from_env() -> ConnectParams {
+    ConnectParams::builder()
+        .user(
+            &env::var("DB_USER").expect("missing DB_USER"),
+            Some(&env::var("DB_PASSWORD").expect("missing DB_PASSWORD")),
+        )
+        .database(&env::var("DB_NAME").expect("missing DB_NAME"))
+        .build(Host::Tcp(env::var("DB_HOST").expect("missing DB_HOST")))
+}
+
+/// Wrapper that returns a PostgreSQL connection to the tests environment db
+pub fn get_connection() -> Connection {
+
+    return Connection::connect(
+        create_connection_params_from_env(),
+        TlsMode::None,
+    ).unwrap();
+}
+
+/// Truncate the content of the unique table 'sentence'
+///
+/// # Arguments:
+///
+/// `connection` - The PostgreSQL connection object
+pub fn clear(connection: &Connection) {
+
+    connection.execute("TRUNCATE TABLE sentence;", &[]).unwrap();
+}

--- a/tests/test_create_sentence.rs
+++ b/tests/test_create_sentence.rs
@@ -1,0 +1,29 @@
+extern crate reqwest;
+
+use std::collections::HashMap;
+
+use reqwest::StatusCode;
+
+mod db;
+
+#[test]
+fn test_post_sentence_returns_200() {
+
+    let connection = db::get_connection();
+    db::clear(&connection);
+
+    let mut json = HashMap::new();
+    json.insert("text", "This is a sentence.");
+    json.insert("iso639_3", "eng");
+
+    let client = reqwest::Client::new();
+    let response = client.post("http://localhost:8000/sentences")
+        .json(&json)
+        .send()
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::Created,
+    );
+}


### PR DESCRIPTION
The test simply checks that the POST sentence API returns 201 on success. The added tests/interfaces/db module is added to truncate the sentence database content before every POST test.