### PR TITLE
add a test in order to check that posting a sentence with an existing content returns a conflict status code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,9 @@ fn main() {
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
             language_id INTEGER REFERENCES language (id) ON DELETE SET NULL,
             added_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-            content TEXT NOT NULL UNIQUE,
-            structure XML DEFAULT NULL
+            content TEXT NOT NULL,
+            structure XML DEFAULT NULL,
+            UNIQUE (language_id, content)
         )
         "#,
         &[],

--- a/tests/test_create_sentence.rs
+++ b/tests/test_create_sentence.rs
@@ -238,7 +238,7 @@ fn test_post_sentence_structure_that_does_not_match_content_returns_400() {
 }
 
 #[test]
-fn test_post_sentence_with_used_content_returns_409() {
+fn test_post_sentence_with_used_content_and_language_returns_409() {
 
     let connection = db::get_connection();
     db::clear(&connection);
@@ -275,5 +275,52 @@ fn test_post_sentence_with_used_content_returns_409() {
     assert_eq!(
         response.status(),
         StatusCode::Conflict,
+    );
+}
+
+#[test]
+fn test_post_sentence_with_used_content_and_different_language_returns_200() {
+
+    let connection = db::get_connection();
+    db::clear(&connection);
+
+    let first_sentence_iso639_3 = "eng";
+    db::insert_language(
+        &connection,
+        &first_sentence_iso639_3,
+    );
+
+    let second_sentence_iso639_3 = "fra";
+    db::insert_language(
+        &connection,
+        &second_sentence_iso639_3,
+    );
+
+    let sentence_text = "This is one sentence.";
+    db::insert_sentence(
+        &connection,
+        &uuid::Uuid::new_v4(),
+        &sentence_text,
+        &first_sentence_iso639_3,
+    );
+
+    let mut json = HashMap::new();
+    json.insert("text", sentence_text.to_string());
+    json.insert("iso639_3", second_sentence_iso639_3.to_string());
+
+    let client = reqwest::Client::new();
+
+    let url = format!(
+        "{}/sentences",
+        tests_commons::SERVICE_URL,
+    );
+    let response = client.post(&url)
+        .json(&json)
+        .send()
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::Created,
     );
 }


### PR DESCRIPTION
Request by this issue https://github.com/allan-simon/sentence-aligner-rust/issues/41. The content column has a unique constraint, so the limitation is already implemented.